### PR TITLE
rc `2023.10.26`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: NDBC API CI
+name: otbench ci
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Upload otbench to PyPi
 
 on:
   release:

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,15 @@ with open('README.md', 'r', encoding='utf-8') as f:
 setuptools.setup(
     name='otb',
     packages=setuptools.find_packages(exclude=['*tests*', '*notebooks*']),
-    version='0.23.10.23',
+    version='0.23.10.26',
     license='MIT',
     description='Consistent benchmarks for evaluating optical turbulence strength models.',
     author='Chris Jellen',
     author_email='cdjellen@gmail.com',
-    url='https://github.com/cdjellen/ot-bench',
+    url='https://github.com/cdjellen/otbench',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    download_url='https://github.com/cdjellen/ot-bench/tarball/main',
+    download_url='https://github.com/cdjellen/otbench/tarball/main',
     keywords=['optics', 'turbulence', 'benchmark', 'otb', 'python3'],
     install_requires=['astral', 'pandas', 'requests', 'scikit-learn', 'xarray'],
     classifiers=[


### PR DESCRIPTION
* Update CI and coverage pipelines
* Changed the `short_name` of the `temporal_hour` variable in `usna_cn2_lg.nc` from `temporal.hour` to `th`
* Changed repo name from `ot-bench` to `otbench`
* Fixed typos and formatting for readmes