### PR TITLE
release `2023.10.26`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Release version `2023.10.26` of `otbench`
* first public release
* improved test coverage
* full README coverage
* deemed production ready for atmospheric research and benchmarking

Future improvements:
* make all baseline models deterministic in their scores
* add a new `usna_cn2_full` dataset with all available data across all sources, and without interpolation
* improve repository with discussions and templates for contributing and issues